### PR TITLE
Add ability to supress output

### DIFF
--- a/examples/editor-development/_editor-development.maxpat
+++ b/examples/editor-development/_editor-development.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 888.0, 66.0, 545.0, 841.0 ],
+		"rect" : [ 888.0, 66.0, 392.0, 841.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -40,12 +40,36 @@
 		"assistshowspatchername" : 0,
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-49",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 417.0, 410.0, 101.0, 22.0 ],
+					"text" : "supress_output 1"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-48",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 417.0, 377.0, 101.0, 22.0 ],
+					"text" : "supress_output 0"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-47",
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 299.0, 477.0, 112.0, 22.0 ],
+					"patching_rect" : [ 292.0, 477.0, 112.0, 22.0 ],
 					"text" : "ephemeral_mode 0"
 				}
 
@@ -57,7 +81,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 299.0, 447.0, 112.0, 22.0 ],
+					"patching_rect" : [ 292.0, 447.0, 112.0, 22.0 ],
 					"text" : "ephemeral_mode 1"
 				}
 
@@ -92,7 +116,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 299.0, 410.0, 113.0, 22.0 ],
+					"patching_rect" : [ 292.0, 410.0, 113.0, 22.0 ],
 					"text" : "ignore_keys_id 100"
 				}
 
@@ -104,7 +128,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 299.0, 377.0, 119.0, 22.0 ],
+					"patching_rect" : [ 292.0, 377.0, 119.0, 22.0 ],
 					"text" : "ignore_keys_id 8706"
 				}
 
@@ -1232,6 +1256,20 @@
 				"patchline" : 				{
 					"destination" : [ "obj-31", 0 ],
 					"source" : [ "obj-47", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-31", 0 ],
+					"source" : [ "obj-48", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-31", 0 ],
+					"source" : [ "obj-49", 0 ]
 				}
 
 			}

--- a/examples/editor-development/_editor-development.maxpat
+++ b/examples/editor-development/_editor-development.maxpat
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 888.0, 66.0, 392.0, 841.0 ],
+		"rect" : [ 638.0, 66.0, 642.0, 841.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -1002,8 +1002,8 @@
 					"numinlets" : 1,
 					"numoutlets" : 3,
 					"outlettype" : [ "", "", "" ],
-					"patching_rect" : [ 244.5, 245.0, 159.0, 22.0 ],
-					"text" : "tw.gl.repl editor-dev 588 258"
+					"patching_rect" : [ 244.5, 245.0, 267.0, 22.0 ],
+					"text" : "tw.gl.repl editor-dev 588 258 @supress_output 1"
 				}
 
 			}

--- a/javascript/src/MaxBindings/MaxBindingGenerator.ts
+++ b/javascript/src/MaxBindings/MaxBindingGenerator.ts
@@ -207,6 +207,21 @@ function getCustomFunctionDefinitions(): Array<Object> {
         comment: "If true then also output the text matrix name behind the command routing jit_matrix when code is run. Note that this does not stop other messages being output from the repl"
     });
     genFuncs.push({
+        functionName: "supress_output",
+        handlerInlet: 0,
+        isMethod: true,
+        isAttribute: false,
+        paramCount: 1,
+        params: [
+            {
+                name: "v",
+                default: false,
+                type: "bang/int",
+            }
+        ],
+        comment: "If true then dont output the formatted messages. Can be used with output_matrix to only output the jit_matrix name from the repl"
+    });
+    genFuncs.push({
         functionName: "ephemeral_mode",
         handlerInlet: 0,
         isAttribute: true,

--- a/javascript/src/MaxBindings/MaxBindingGenerator.ts
+++ b/javascript/src/MaxBindings/MaxBindingGenerator.ts
@@ -195,7 +195,7 @@ function getCustomFunctionDefinitions(): Array<Object> {
         functionName: "output_matrix",
         handlerInlet: 0,
         isMethod: true,
-        isAttribute: false,
+        isAttribute: true,
         paramCount: 1,
         params: [
             {
@@ -210,7 +210,7 @@ function getCustomFunctionDefinitions(): Array<Object> {
         functionName: "supress_output",
         handlerInlet: 0,
         isMethod: true,
-        isAttribute: false,
+        isAttribute: true,
         paramCount: 1,
         params: [
             {

--- a/javascript/src/MaxBindings/templates/main.hbs
+++ b/javascript/src/MaxBindings/templates/main.hbs
@@ -33,6 +33,19 @@ function output_matrix(v) {
 }
 
 /**
+ * If SUPRESS_OUTPUT === true then dont output the formatted messages.
+ * Can be used with output_matrix to only output the jit_matrix name from the repl
+ */
+var SUPRESS_OUTPUT = false;
+function supress_output(v){
+    if(v === undefined){
+        SUPRESS_OUTPUT = !SUPRESS_OUTPUT
+    } else {
+        SUPRESS_OUTPUT = v != 0;
+    }
+}
+
+/**
  * If EPHEMERAL_MODE === true then the buffer will clear every time you run/execute
  * If you run all it will empty all, if you run line it will empty the current line
  */
@@ -131,8 +144,10 @@ function run_line() {
 }
 
 function run_output(out){
-    for (var a = 0; a < out.length; a++) {
-        outlet(0, out[a]);
+    if(SUPRESS_OUTPUT === false){
+        for (var a = 0; a < out.length; a++) {
+            outlet(0, out[a]);
+        }
     }
     if (OUT_MAT) {
         outlet(0, "jit_matrix " + i.glRender.textMtx.name);


### PR DESCRIPTION
add a new function supress_output to repl, so that it is possible to only output the matrix and not the commands in the editor. This makes the repl compatible with the way mercury deals with output from the repl